### PR TITLE
Add Dubs Skylights support

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -174,5 +174,6 @@
     <li IfModActive="aoba.deadmanswitch.motorized">Mods and Shit/DMS Motorized</li>
     <li IfModActive="vin.warehouse.storage">Mods and Shit/Warehouse Storage</li>
     <li IfModActive="jf.royalcarpets">Mods and Shit/Royal Carpets</li>
+    <li IfModActive="dubwise.dubsskylights">Mods and Shit/Dubs Skylights</li>
   </v1.6>
 </loadFolders>

--- a/Mods and Shit/Dubs Skylights/Patches/dubs skylights patch.xml
+++ b/Mods and Shit/Dubs Skylights/Patches/dubs skylights patch.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <!-- Remove Skylights category -->
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/DesignationCategoryDef[defName="skylights"]</xpath>
+    </Operation>
+
+    <!-- Add special skylights designator -->
+    <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/DesignationCategoryDef[defName="Ferny_Lighting"]/specialDesignatorClasses</xpath>
+    <value>
+        <li>Dubs_Skylight.Designator_RemoveSkylights</li>
+    </value>
+    </Operation>
+
+    <!-- Add Ferny_Lighting category to buildables -->
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="SkyLightA"]</xpath>
+        <value>
+            <designationCategory>Ferny_Lighting</designationCategory>
+        </value>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="SkyLightB"]</xpath>
+        <value>
+            <designationCategory>Ferny_Lighting</designationCategory>
+        </value>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="SkyLightC"]</xpath>
+        <value>
+            <designationCategory>Ferny_Lighting</designationCategory>
+        </value>
+    </Operation>
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="SkyLightD"]</xpath>
+        <value>
+            <designationCategory>Ferny_Lighting</designationCategory>
+        </value>
+    </Operation>
+</Patch>


### PR DESCRIPTION
# Motivations
[Dub's skylights](https://steamcommunity.com/sharedfiles/filedetails/?id=833899765&searchtext=skylight) adds it's own category that clutters up the architect menu. To me it counts as lighting, and should go into the lighting category

# Modifications
- Remove Dubs Skylights built in category
- Replace Dubs Skylights buildable categories with Ferny Lighting

# Results
<img width="1909" height="434" alt="image" src="https://github.com/user-attachments/assets/2295c84b-bdda-4b50-b344-0d8c05255f66" />
