### PR TITLE
Fixed Bioform Matrix patch

### DIFF
--- a/Mods and Shit/Bioform Matrix/Patches/bioform matrix patch.xml
+++ b/Mods and Shit/Bioform Matrix/Patches/bioform matrix patch.xml
@@ -3,7 +3,7 @@
 	
 	<Operation Class="PatchOperationReplace">
 		<success>Always</success>
-		<xpath>Defs/ThingDef[defName="BiosculpterPod"]/designationCategory</xpath>
+		<xpath>Defs/ThingDef[defName="BiosculptorLink"]/designationCategory</xpath>
 		<value>
 			<designationCategory>Ferny_Medical</designationCategory>
 		</value>


### PR DESCRIPTION
Wrong patch code was previously deleted. This now moves the Bioform Matrix to Biotech->Medical as intended.