### PR TITLE
VFEM2 draught lab fix

### DIFF
--- a/Mods and Shit/VFE Medieval 2/Patches/vfe medieval 2 patch.xml
+++ b/Mods and Shit/VFE Medieval 2/Patches/vfe medieval 2 patch.xml
@@ -124,6 +124,22 @@
                     </value>
                 </Operation>
 
+	            <Operation Class="PatchOperationReplace">
+		            <success>Always</success>
+		            <xpath>Defs/ThingDef[defName="VFEM2_AlchemicalWorkbench"]/designationCategory</xpath>
+		            <value>
+			            <designationCategory>Ferny_Production</designationCategory>
+		            </value>
+	            </Operation>
+
+	            <Operation Class="PatchOperationReplace">
+		            <success>Always</success>
+		            <xpath>Defs/ThingDef[defName="VFEM2_AlchemicalWorkbench_Electric"]/designationCategory</xpath>
+		            <value>
+			            <designationCategory>Ferny_Production</designationCategory>
+		            </value>
+	            </Operation>
+
 <!-- DECORATIONS -->
                 <Operation Class="PatchOperationReplace">
                     <success>Always</success>


### PR DESCRIPTION
VFE Medieval 2 draught labs are now in Make->Production. They were not patched previously.