### PR TITLE
Rimatomics support added

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -277,6 +277,7 @@
         <li>wanzi.smallgraves</li>
         <li>wanzi.biggraves</li>
 		<li>relvl.digitalstorageunit</li>
+		<li>dubwise.rimatomics</li>
         <!-- (Add new mods here ^^^^^) -->
     </loadAfter>
 </ModMetaData>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -218,6 +218,7 @@
     <li IfModActive="thatthing.mycohazard">Mods and Shit/Mycohazard</li>
     <li IfModActive="wanzi.smallgraves">Mods and Shit/Small Graves and Sarcophaguses</li>
     <li IfModActive="wanzi.biggraves">Mods and Shit/Big Graves and Sarcophaguses</li>	
+	<li IfModActive="dubwise.rimatomics">Mods and Shit/Dubs Rimatomics</li>
             <!-- (Add new mods here ^^^^^) -->
   </v1.6>
 </loadFolders>

--- a/Mods and Shit/Dubs Rimatomics/Patches/dubs rimatomics patch.xml
+++ b/Mods and Shit/Dubs Rimatomics/Patches/dubs rimatomics patch.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	
+<!-- Rimatomics category to Power->Nuclear -->
+
+	<Operation Class="PatchOperationAddModExtension">
+		<success>Always</success>
+		<xpath>Defs/DesignationCategoryDef[defName="Rimatomics"]</xpath>
+		<value>
+
+			<li Class="BetterArchitect.NestedCategoryExtension">
+				<parentCategory>Power</parentCategory>
+			</li>
+
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/DesignationCategoryDef[defName="Rimatomics"]/label</xpath>
+		<value>
+			<label>Nuclear</label>
+		</value>
+	</Operation>
+
+<!-- WALLS -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="RadiationShielding"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_Walls</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- DOORS -->
+	
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="DU_Blastdoor"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_Doors</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- PRODUCTION -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="TableRimatomicsMachining"]</xpath>
+		<value>
+			<designationCategory>Ferny_Production</designationCategory>
+		</value>
+	</Operation>
+
+	<!-- Remove reference to Rimatomics -->
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="TableRimatomicsMachining"]/label</xpath>
+		<value>
+			<label>Atomics machining table</label>
+		</value>
+	</Operation>
+	
+<!-- PROCESSING PRODUCTION -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="PlutoniumProcessor"]</xpath>
+		<value>
+			<designationCategory>Ferny_ProcessingProduction</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- RESEARCH -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="NuclearResearchBench"]</xpath>
+		<value>
+			<designationCategory>Ferny_ResearchProduction</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="ResearchReactor"]</xpath>
+		<value>
+			<designationCategory>Ferny_ResearchProduction</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="WeaponsBench"]</xpath>
+		<value>
+			<designationCategory>Ferny_ResearchProduction</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- WEAPONS -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[@ParentName="BasedWeapon"]</xpath>
+		<value>
+			<designationCategory>Ferny_Weapons</designationCategory>
+		</value>
+	</Operation>
+
+<!-- COMBAT INFRASTRUCTURE -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="PPC"]</xpath>
+		<value>
+			<designationCategory>Ferny_CombatInfrastructure</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="PPCWeaponsConsole"]</xpath>
+		<value>
+			<designationCategory>Ferny_CombatInfrastructure</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="RadarDish"]</xpath>
+		<value>
+			<designationCategory>Ferny_CombatInfrastructure</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="RimatomicsShieldGenerator"]</xpath>
+		<value>
+			<designationCategory>Ferny_CombatInfrastructure</designationCategory>
+		</value>
+	</Operation>
+	
+</Patch>


### PR DESCRIPTION
- Research buildings to Ferny_ResearchProduction
- Rimatomics machining table renamed to "Atomics machining table" and moved to Ferny_Production
- Plutonium processor to Ferny_ProcessingProduction
- Turrets to Ferny_Weapons
- Combat support buildings to Ferny_CombatInfrastructure
- Rimatomics category named "Nuclear" and moved under Power