### PR TITLE
Update rebuild dac patch.xml

### DIFF
--- a/Mods and Shit/Rebuild DAC/Patches/rebuild dac patch.xml
+++ b/Mods and Shit/Rebuild DAC/Patches/rebuild dac patch.xml
@@ -27,7 +27,7 @@
                 </Operation>
 
 <!-- HEATING -->
-                <Operation Class="PatchOperationAdd">
+                <Operation Class="PatchOperationReplace">
                     <success>Always</success>
                     <xpath>Defs/ThingDef[@Name="RB_Fireplace"]/designationCategory</xpath>
                     <value>


### PR DESCRIPTION
Fixed an issue with the Heating patch not applying correctly to the Overwall_Fireplace due to duplicated <designationCategory> nodes.