### PR TITLE
VE Chemfuel Unofficial Expansion support added

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -277,6 +277,7 @@
         <li>wanzi.smallgraves</li>
         <li>wanzi.biggraves</li>
 		<li>relvl.digitalstorageunit</li>
+		<li>bambaryla.vcepu</li>
         <!-- (Add new mods here ^^^^^) -->
     </loadAfter>
 </ModMetaData>

--- a/Defs/DesignationCategories.xml
+++ b/Defs/DesignationCategories.xml
@@ -899,8 +899,23 @@
 				<parentCategory>Ferny_Hosting</parentCategory>
 			</li>
 		</modExtensions>
-  </DesignationCategoryDef>  
+  </DesignationCategoryDef>
 
-
+	<!-- VRE Androids and VE Chemfuel Unofficial Expansion both need a neutroamine network category. -->
+	<DesignationCategoryDef>
+		<defName>Ferny_NeutroamineNetwork</defName>
+		<label>Neutroamine</label>
+		<description>Manage neutroamine.</description>
+		<order>7</order>
+		<specialDesignatorClasses>
+			<li>Designator_Cancel</li>
+			<li>Designator_Deconstruct</li>
+		</specialDesignatorClasses>
+		<modExtensions>
+			<li Class="BetterArchitect.NestedCategoryExtension">
+				<parentCategory>VCHE_PipeNetworks</parentCategory>
+			</li>
+		</modExtensions>
+	</DesignationCategoryDef>
 
 </Defs>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -218,6 +218,7 @@
     <li IfModActive="thatthing.mycohazard">Mods and Shit/Mycohazard</li>
     <li IfModActive="wanzi.smallgraves">Mods and Shit/Small Graves and Sarcophaguses</li>
     <li IfModActive="wanzi.biggraves">Mods and Shit/Big Graves and Sarcophaguses</li>	
+	<li IfModActive="bambaryla.vcepu">Mods and Shit/VE Chemfuel Unofficial Expansion</li>                                   <!-- TODO Unpack dropdown -->
             <!-- (Add new mods here ^^^^^) -->
   </v1.6>
 </loadFolders>

--- a/Mods and Shit/VE Chemfuel Unofficial Expansion/Defs/VEChemfuelUnofficialExpansionDesignationCategories.xml
+++ b/Mods and Shit/VE Chemfuel Unofficial Expansion/Defs/VEChemfuelUnofficialExpansionDesignationCategories.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<DesignationCategoryDef MayRequire="ludeon.rimworld.biotech">
+		<defName>Ferny_ToxicWasteNetwork</defName>
+		<label>Toxic Waste</label>
+		<description>Manage toxic waste.</description>
+		<order>6</order>
+		<specialDesignatorClasses>
+			<li>Designator_Cancel</li>
+			<li>Designator_Deconstruct</li>
+		</specialDesignatorClasses>
+		<modExtensions>
+			<li Class="BetterArchitect.NestedCategoryExtension">
+				<parentCategory>VCHE_PipeNetworks</parentCategory>
+			</li>
+		</modExtensions>
+	</DesignationCategoryDef>
+
+	<DesignationCategoryDef>
+		<defName>Ferny_DyeNetwork</defName>
+		<label>Dye</label>
+		<description>Manage dye.</description>
+		<order>6</order>
+		<specialDesignatorClasses>
+			<li>Designator_Cancel</li>
+			<li>Designator_Deconstruct</li>
+		</specialDesignatorClasses>
+		<modExtensions>
+			<li Class="BetterArchitect.NestedCategoryExtension">
+				<parentCategory>VCHE_PipeNetworks</parentCategory>
+			</li>
+		</modExtensions>
+	</DesignationCategoryDef>
+
+</Defs>

--- a/Mods and Shit/VE Chemfuel Unofficial Expansion/Patches/ve chemfuel unofficial expansion patch.xml
+++ b/Mods and Shit/VE Chemfuel Unofficial Expansion/Patches/ve chemfuel unofficial expansion patch.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationConditional">
+		<xpath>/Defs/DesignationCategoryDef[defName="VCHE_PipeNetworks"]</xpath>
+		<match Class="PatchOperationAddModExtension">
+			<success>Always</success>
+			<xpath>Defs/DesignationCategoryDef[defName="Ferny_ToxicWasteNetwork"]</xpath>
+			<value>
+
+				<li Class="BetterArchitect.NestedCategoryExtension">
+					<parentCategory>VCHE_PipeNetworks</parentCategory>
+				</li>
+
+			</value>
+		</match>
+	</Operation>
+
+<!-- TOXIC WASTE -->
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Biotech</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				
+				<!-- Networks -->
+				
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/PipeSystem.PipeNetDef[defName="VCEUE_ToxicWasteNet"]/designator/designationCategoryDef</xpath>
+					<value>
+						<designationCategoryDef>Ferny_ToxicWasteNetwork</designationCategoryDef>
+					</value>
+				</li>
+
+				<!-- Buildings -->
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_ToxicWastePipe"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_UndergroundToxicWastePipe"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_ToxicWasteValve"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_ToxicWasteTank"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_ToxicWasteTap"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_ToxicWasteDrain"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<success>Always</success>
+					<xpath>Defs/ThingDef[defName="VCEUE_WasteDetofixier"]/designationCategory</xpath>
+					<value>
+						<designationCategory>Ferny_ToxicWasteNetwork</designationCategory>
+					</value>
+				</li>
+				
+			</operations>
+		</match>
+	</Operation>
+	
+<!-- NEUTROAMINE-->
+
+	<!-- Networks -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/PipeSystem.PipeNetDef[defName="VREA_NeutroamineNet"]/designator/designationCategoryDef</xpath>
+		<value>
+			<designationCategoryDef>Ferny_NeutroamineNetwork</designationCategoryDef>
+		</value>
+	</Operation>
+
+	<!-- Buildings -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_NeutroamineRefinery"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VREA_NeutroPipe"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VREA_SubterraneanNeutroPipe"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_NeutroamineValve"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_NeutroamineTank"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_NeutroamineTap"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_NeutroamineDrain"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_NeutroamineNetwork</designationCategory>
+		</value>
+	</Operation>
+
+<!-- DYE -->
+	
+	<!-- Networks -->
+	
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/PipeSystem.PipeNetDef[defName="VCEUE_DyeNet"]/designator/designationCategoryDef</xpath>
+		<value>
+			<designationCategoryDef>Ferny_DyeNetwork</designationCategoryDef>
+		</value>
+	</Operation>
+
+	<!-- Buildings -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_DyePipe"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_UndergroundDyePipe"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_DyeValve"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_DyeTank"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_DyeTap"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_DyeDrain"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_DyeRefinery"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_DyeNetwork</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- CHEMFUEL -->
+
+	<!-- Buildings -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_RawPlasteelRefinery"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_ChemfuelNetwork</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_AdvancedAutoWeavery"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_ChemfuelNetwork</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- PROCESSING PRODUCTION -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_Autoclave"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_ProcessingProduction</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="VCEUE_Autoweave"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_ProcessingProduction</designationCategory>
+		</value>
+	</Operation>
+	
+</Patch>

--- a/Mods and Shit/VRE Androids/Defs/VREAndroidsDesignationCategories.xml
+++ b/Mods and Shit/VRE Androids/Defs/VREAndroidsDesignationCategories.xml
@@ -2,22 +2,6 @@
 <Defs>
 
   <DesignationCategoryDef>
-    <defName>Ferny_NeutroamineNetwork</defName>
-    <label>Neutroamine</label>
-    <description>Manage neutroamine.</description>
-    <order>7</order>
-    <specialDesignatorClasses>
-      <li>Designator_Cancel</li>
-      <li>Designator_Deconstruct</li>
-    </specialDesignatorClasses>
-    <modExtensions>
-      <li Class="BetterArchitect.NestedCategoryExtension">
-        <parentCategory>VCHE_PipeNetworks</parentCategory>
-      </li>
-    </modExtensions>
-  </DesignationCategoryDef>
-
-  <DesignationCategoryDef>
     <defName>Ferny_Androids</defName>
     <label>Androids</label>
     <description>Build androids.</description>


### PR DESCRIPTION
Also had to move Ferny_NeutroamineNetwork to DesignationCategories.xml in order to support any combination of VRE Androids or VE Chemfuel Unofficial Expansion being loaded.