### PR TITLE
Misc fixes for pillbug2 patches

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -191,11 +191,11 @@
     <li IfModActive="oskarpotocki.vfe.pirates">Mods and Shit/VFE Pirates</li>
     <li IfModActive="trugerman.altdeuteriumextractor">Mods and Shit/Piped Deuterium Extractor</li>
     <li IfModActive="ilyvion.colonymanagerredux">Mods and Shit/Colony Manager Redux</li>
-    <li IfModActive="aelanna.eccentrictech.defensegrid">Mods and Shit/Eccentric Tech Defense Grid</li>                      <!-- TODO Move pipe deconstruct designator -->
-    <li IfModActive="aelanna.eccentrictech.fusionpower">Mods and Shit/Eccentric Tech Fusion Power</li>                      <!-- TODO Move pipe deconstruct designator -->
+    <li IfModActive="aelanna.eccentrictech.defensegrid">Mods and Shit/Eccentric Tech Defense Grid</li>
+    <li IfModActive="aelanna.eccentrictech.fusionpower">Mods and Shit/Eccentric Tech Fusion Power</li>
     <li IfModActive="mrhydralisk.complementaryodyssey">Mods and Shit/Complementary Odyssey</li>
     <li IfModActive="windwardsnow.mechanitorweapons">Mods and Shit/Mechanitor Weapons</li>                                  <!-- TODO Unpack turret dropdown -->
-    <li IfModActive="mjeiouws.outlander.continuouscontention">Mods and Shit/Outlander Solutions Continuous Contention</li>  <!-- TODO Move pipe deconstruct designator -->
+    <li IfModActive="mjeiouws.outlander.continuouscontention">Mods and Shit/Outlander Solutions Continuous Contention</li>
     <li IfModActive="mlie.jwlatmosphericwaterprocessor">Mods and Shit/Atmospheric Water Processor</li>
     <li IfModActive="mlie.reinforcedmechanoid2">Mods and Shit/Reinforced Mechanoid 2</li>                                   <!-- Reinforced Mechanoid 2 patch split for compatibility with standalone buildings -->
 	<li IfModActive="mlie.reinforcedmechanoid2">Mods and Shit/Gestalt Engine</li>

--- a/Mods and Shit/Ancient Mining Industry/Patches/ancient mining industry patch.xml
+++ b/Mods and Shit/Ancient Mining Industry/Patches/ancient mining industry patch.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 	
+<!-- PROCESSING PRODUCTION -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="BreadMoAM_OreDressingMachine"]</xpath>
+		<value>
+			<designationCategory>Ferny_ProcessingProduction</designationCategory>
+		</value>
+	</Operation>
+	
 <!-- WEAPONS -->
 
 	<Operation Class="PatchOperationReplace">

--- a/Mods and Shit/DMS The Dead Man's Switch/Patches/dead mans switch patch.xml
+++ b/Mods and Shit/DMS The Dead Man's Switch/Patches/dead mans switch patch.xml
@@ -4,13 +4,6 @@
 
 <Patch>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/DesignationCategoryDef[defName="DMS_Category"]/label</xpath>
-		<value>
-			<label>Automatroids</label>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationAddModExtension">
 		<success>Always</success>
 		<xpath>Defs/DesignationCategoryDef[defName="DMS_Category"]</xpath>

--- a/Mods and Shit/Eccentric Tech Defense Grid/Patches/eccentric tech defense grid patch.xml
+++ b/Mods and Shit/Eccentric Tech Defense Grid/Patches/eccentric tech defense grid patch.xml
@@ -1,7 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+	
+<!-- Move network deconstruct gizmos -->
 
-	<!-- COMBAT INFRASTRUCTURE -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Ferny_Weapons"]/specialDesignatorClasses</xpath>
+		<value>
+			<li>EccentricDefenseGrid.Designator_DeconstructConduit</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Ferny_Barricades"]/specialDesignatorClasses</xpath>
+		<value>
+			<li>EccentricDefenseGrid.Designator_DeconstructConduit</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Ferny_CombatInfrastructure"]/specialDesignatorClasses</xpath>
+		<value>
+			<li>EccentricDefenseGrid.Designator_DeconstructConduit</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Security"]/specialDesignatorClasses/li[text()="EccentricDefenseGrid.Designator_DeconstructConduit"]</xpath>
+	</Operation>
+
+<!-- COMBAT INFRASTRUCTURE -->
 
 	<Operation Class="PatchOperationAdd">
 		<success>Always</success>
@@ -16,6 +47,32 @@
 		<xpath>Defs/ThingDef[defName="Eccentric_DefenseConduit"]/designationCategory</xpath>
 		<value>
 			<designationCategory>Ferny_CombatInfrastructure</designationCategory>
+		</value>
+	</Operation>
+	
+<!-- BARRICADES -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="Eccentric_ShieldProjector"]</xpath>
+		<value>
+			<designationCategory>Ferny_Barricades</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="Eccentric_ShieldProjectorWide"]</xpath>
+		<value>
+			<designationCategory>Ferny_Barricades</designationCategory>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="Eccentric_ShieldProjector3x3Wide"]</xpath>
+		<value>
+			<designationCategory>Ferny_Barricades</designationCategory>
 		</value>
 	</Operation>
 

--- a/Mods and Shit/Eccentric Tech Fusion Power/Patches/eccentric tech fusion power patch.xml
+++ b/Mods and Shit/Eccentric Tech Fusion Power/Patches/eccentric tech fusion power patch.xml
@@ -1,7 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
+
+<!-- Move network deconstruct gizmos -->
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Ferny_PowerGeneration"]/specialDesignatorClasses</xpath>
+		<value>
+			<li>EccentricPower.Designator_DeconstructPipe</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Ferny_PowerStorage"]/specialDesignatorClasses</xpath>
+		<value>
+			<li>EccentricPower.Designator_DeconstructPipe</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Ferny_PowerManagement"]/specialDesignatorClasses</xpath>
+		<value>
+			<li>EccentricPower.Designator_DeconstructPipe</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<success>Always</success>
+		<xpath>/Defs/DesignationCategoryDef[defName="Power"]/specialDesignatorClasses/li[text()="EccentricPower.Designator_DeconstructPipe"]</xpath>
+	</Operation>
 	
-	<!-- POWER INFRASTRUCTURE -->
+<!-- POWER INFRASTRUCTURE -->
 
 	<Operation Class="PatchOperationReplace">
 		<success>Always</success>
@@ -64,4 +95,5 @@
 		</value>
 	</Operation>
 	
+
 </Patch>

--- a/Mods and Shit/GravTech/Patches/gravtech patch.xml
+++ b/Mods and Shit/GravTech/Patches/gravtech patch.xml
@@ -20,7 +20,17 @@
 			<designationCategory>Ferny_Production</designationCategory>
 		</value>
 	</Operation>
+	
+<!-- OTHER PRODUCTION -->
 
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="AsteroidCollector"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Production</designationCategory>
+		</value>
+	</Operation>
+	
 <!-- MEDICAL -->
 
 	<Operation Class="PatchOperationReplace">
@@ -28,6 +38,16 @@
 		<xpath>Defs/ThingDef[defName="AdvShip_TimeFasterPod"]/designationCategory</xpath>
 		<value>
 			<designationCategory>Ferny_Medical</designationCategory>
+		</value>
+	</Operation>
+
+<!-- BARRICADES -->
+
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/ThingDef[defName="AdvShip_ShieldGenerator"]/designationCategory</xpath>
+		<value>
+			<designationCategory>Ferny_Barricades</designationCategory>
 		</value>
 	</Operation>
 

--- a/Mods and Shit/Outlander Solutions Continuous Contention/Patches/outlander solutions continuous contention patch.xml
+++ b/Mods and Shit/Outlander Solutions Continuous Contention/Patches/outlander solutions continuous contention patch.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-	
+
 <!-- WORLD -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PipeSystem.PipeNetDef[defName="ContinuousContention_DefenseNet"]/designator/designationCategoryDef</xpath>
+		<value>
+			<designationCategoryDef>Ferny_World</designationCategoryDef>
+		</value>
+	</Operation>
 	
 	<Operation Class="PatchOperationReplace">
 		<success>Always</success>

--- a/Mods and Shit/Universal Conduit/Patches/universal conduit patch.xml
+++ b/Mods and Shit/Universal Conduit/Patches/universal conduit patch.xml
@@ -21,6 +21,14 @@
 						<designationCategory>VCHE_PipeNetworks</designationCategory>
 					</value>
 				</li>
+
+				<li Class="PatchOperationAdd">
+					<success>Always</success>
+					<xpath>/Defs/DesignationCategoryDef[defName="VCHE_PipeNetworks"]/specialDesignatorClasses</xpath>
+					<value>
+						<li>Designator_DeconstructConduit</li>
+					</value>
+				</li>
 				
 			</operations>
 		</match>


### PR DESCRIPTION
- Removed DMS category renaming - it is overridden by language strings
- Moved network deconstruct designators for Outlander Solutions Continuous Contention, Eccentric Tech Defense Grid and Fusion Power, and Universal Conduit.
- Moved Ancient mining industry Ore dressing machine to Ferny_ProcessingProduction
- Moved Eccentric Tech Defense Grid shield generators to Ferny_Barricades
- Moved GravTech asteroid collector to Production->Other and shield generator to Ferny_Barricades