### PR TITLE
Moved Outlander Solutions Continuous Contention's skyscreen turret to Barricades

### DIFF
--- a/Mods and Shit/Outlander Solutions Continuous Contention/Patches/outlander solutions continuous contention patch.xml
+++ b/Mods and Shit/Outlander Solutions Continuous Contention/Patches/outlander solutions continuous contention patch.xml
@@ -53,15 +53,17 @@
 		</value>
 	</Operation>
 	
-<!-- WEAPONS -->
+<!-- BARRICADES -->
 
 	<Operation Class="PatchOperationAdd">
 		<success>Always</success>
 		<xpath>Defs/ThingDef[defName="ContinuousContention_Turret_Skyscreen"]</xpath>
 		<value>
-			<designationCategory>Ferny_Weapons</designationCategory>
+			<designationCategory>Ferny_Barricades</designationCategory>
 		</value>
 	</Operation>
+	
+<!-- WEAPONS -->
 	
 	<Operation Class="PatchOperationAdd">
 		<success>Always</success>


### PR DESCRIPTION
It is intended to serve a defensive role against mortars and drop pods, like a shield