### PR TITLE
Tiny Workbenchs Patch

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -356,6 +356,7 @@
     <li IfModActive="phaneron.basic.storage">Mods and Shit/Phaneron Basic Storage</li>
     <li IfModActive="tug.minotaur">Mods and Shit/Roo Minotaur</li>
     <li IfModActive="bjr1984.dubsskylights.addon">Mods and Shit/Dubs Skylights Addon</li>
+    <li IfModActive="Mlie.TinyWorkbenchs">Mods and Shit/Tiny Workbenchs</li>
     <!-- (Add new mods here ^^^^^) -->
   </v1.6>
 </loadFolders>

--- a/Mods and Shit/Tiny Workbenchs/Patches/Tiny Workbenchs.xml
+++ b/Mods and Shit/Tiny Workbenchs/Patches/Tiny Workbenchs.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Patch>
+
+    <!-- CORE MOD CONTENT -->
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_TableSculptingMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_TableButcherMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Kitchen</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_HandTailoringBenchMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_ElectricTailoringBenchMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_FueledSmithyMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_ElectricSmithyMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_TableMachiningMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_ElectricStoveMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Kitchen</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_FueledStoveMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Kitchen</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_TableStonecutterMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_ProcessingProduction</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_BreweryMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Kitchen</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_DrugLabMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_TableSculptingMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_ElectricSmelterMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_ProcessingProduction</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_FabricationBenchMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_TableSculptingMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_Production</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_SimpleResearchBenchMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_ResearchProduction</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationAdd">
+        <xpath>Defs/ThingDef[defName="TWB_HiTechResearchBenchMini"]</xpath>
+        <value>
+            <designationCategory Inherit="False">Ferny_ResearchProduction</designationCategory>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/ThingDef[defName="TWB_NutrientPasteDispenser"]/designationCategory</xpath>
+        <value>
+            <designationCategory>Ferny_Kitchen</designationCategory>
+        </value>
+    </Operation>
+
+    <!-- MOD PATCH CONTENT -->
+
+    <!-- Combat Extended -->
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_AmmoBenchMini"]</xpath>
+        <match Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TWB_AmmoBenchMini"]</xpath>
+            <value>
+                <designationCategory Inherit="False">Ferny_Production</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <!-- VE Helixien Gas -->
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VHGE_GasPoweredSmelterMini"]</xpath>
+        <match Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TWB_VHGE_GasPoweredSmelterMini"]/designationCategory</xpath>
+            <value>
+                <designationCategory>Ferny_PowerGeneration</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VHGE_GasPoweredStoveMini"]</xpath>
+        <match Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TWB_VHGE_GasPoweredStoveMini"]/designationCategory</xpath>
+            <value>
+                <designationCategory>Ferny_HelixienGasNetwork</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VHGE_GasPoweredSmithyMini"]</xpath>
+        <match Class="PatchOperationReplace">
+            <xpath>Defs/ThingDef[defName="TWB_VHGE_GasPoweredSmithyMini"]/designationCategory</xpath>
+            <value>
+                <designationCategory>Ferny_HelixienGasNetwork</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <!-- VFE Production -->
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VFE_TableButcherElectricMini"]</xpath>
+        <match Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TWB_VFE_TableButcherElectricMini"]</xpath>
+            <value>
+                <designationCategory Inherit="False">Ferny_Kitchen</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VFE_TableDrugLabElectricMini"]</xpath>
+        <match Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TWB_VFE_TableDrugLabElectricMini"]</xpath>
+            <value>
+                <designationCategory Inherit="False">Ferny_Production</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VFE_FueledSmelterMini"]</xpath>
+        <match Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TWB_VFE_FueledSmelterMini"]</xpath>
+            <value>
+                <designationCategory Inherit="False">Ferny_ProcessingProduction</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+    <Operation Class="PatchOperationConditional">
+        <xpath>Defs/ThingDef[defName="TWB_VFE_TableStonecutterElectricMini"]</xpath>
+        <match Class="PatchOperationAdd">
+            <xpath>Defs/ThingDef[defName="TWB_VFE_TableStonecutterElectricMini"]</xpath>
+            <value>
+                <designationCategory Inherit="False">Ferny_ProcessingProduction</designationCategory>
+            </value>
+        </match>
+    </Operation>
+
+</Patch>


### PR DESCRIPTION
Adding in support for Mlie's [Tiny Workbenchs (Continued)](https://steamcommunity.com/sharedfiles/filedetails/?id=2387981423) mod. cc @emipa606

I noticed the tiny stoves weren't changing the room type to `Kitchen` and tracked it down to this mod causing the behavior. Assumed it was something to do with the categorization, so I tried my hand at adding the Buildings to the new categories which fixed the room type issue.  
There might be some other root cause affecting the room type behavior, but I couldn't figure that out.

Haven't contributed to a mod before, so please let me know if anything looks out of place.

Tested against `VE: Helixien Gas`, `VFE: Production`, `SimpleFX: Smoke` to cover Tiny Workbenchs' patches to those mods.  
Did not test against `Combat Extended`, but I wouldn't expect any issues with the tiny loading bench.

---

And of course, thanks to both of ya for all your excellent modding work.