### PR TITLE
Update rrf rapture patch.xml

### DIFF
--- a/Mods and Shit/RR Furniture Rapture/Patches/rrf rapture patch.xml
+++ b/Mods and Shit/RR Furniture Rapture/Patches/rrf rapture patch.xml
@@ -120,7 +120,8 @@
             defName="RRDesktopThree" or
             defName="RRGojaRadio" or
             defName="RRBigStereoConsole" or
-            defName="RRStereoConsole"
+            defName="RRStereoConsole" or
+			defName="RRHomeTVTwo"
         ]</xpath>
         <value>
             <designationCategory>Joy</designationCategory>
@@ -146,7 +147,8 @@
             defName="RRCupboard" or
             defName="RRCupboardTwo" or
             defName="RRBookshelfOne" or
-            defName="RRCupboardThree"
+            defName="RRCupboardThree" or
+			defName="RRRefrigerator"
         ]</xpath>
         <value>
             <designationCategory>Furniture</designationCategory>


### PR DESCRIPTION
Resolves two red errors on launch from leftover items trying to slot into removed designationCategory