### PR TITLE
Add compat for LWM's Deep Storage and Simple Storage Reborn

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -177,6 +177,8 @@
     <li IfModActive="oskarpotocki.vfe.deserters">Mods and Shit/VFE Deserters</li>                                           <!-- Implicit support for Pressure Plate -->
     <li IfModActive="oskarpotocki.vfe.tribals">Mods and Shit/VFE Tribals</li>
     <li IfModActive="adaptive.storage.framework">Mods and Shit/Adaptive Storage Framework</li>
+    <li IfModActive="lwm.deepstorage">Mods and Shit/LWM's Deep Storage</li>
+    <li IfModActive="gideon.simplestorage">Mods and Shit/Simple Storage Reborn</li>
     <li IfModActive="sarg.alphaprefabs">Mods and Shit/Alpha Prefabs</li>
     <li IfModActive="mlie.enterhere">Mods and Shit/Enter Here</li>
     <li IfModActive="adamas.hospital">Mods and Shit/Hospital</li>

--- a/Mods and Shit/LWM's Deep Storage/Patches/lwm deep storage patch.xml
+++ b/Mods and Shit/LWM's Deep Storage/Patches/lwm deep storage patch.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/DesignationCategoryDef[defName="LWM_DS_Storage"]/label</xpath>
+			<value>
+				<label>Deep Storage</label>
+			</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/DesignationCategoryDef[defName="LWM_DS_Storage"]/order</xpath>
+			<value>
+				<order>2</order>
+			</value>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<success>Always</success>
+		<xpath>Defs[DesignationCategoryDef/defName="LWM_DS_Storage"]</xpath>
+		<match Class="PatchOperationAdd">
+                    <success>Always</success>
+                    <xpath>Defs/DesignationCategoryDef[defName="LWM_DS_Storage"]</xpath>
+                    <value>
+                        <modExtensions>
+                        <li Class="BetterArchitect.NestedCategoryExtension">
+                            <parentCategory>Ferny_Storage</parentCategory>
+                        </li>
+                        </modExtensions>
+                    </value>
+		</match>
+	</Operation>
+</Patch>

--- a/Mods and Shit/Simple Storage Reborn/Patches/simple storage reborn patch.xml
+++ b/Mods and Shit/Simple Storage Reborn/Patches/simple storage reborn patch.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/DesignationCategoryDef[defName="SimpleStorage"]/label</xpath>
+			<value>
+				<label>Simple Storage</label>
+			</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>Defs/DesignationCategoryDef[defName="SimpleStorage"]/order</xpath>
+			<value>
+				<order>3</order>
+			</value>
+	</Operation>
+	<Operation Class="PatchOperationConditional">
+		<success>Always</success>
+		<xpath>Defs[DesignationCategoryDef/defName="SimpleStorage"]</xpath>
+		<match Class="PatchOperationAdd">
+                    <success>Always</success>
+                    <xpath>Defs/DesignationCategoryDef[defName="SimpleStorage"]</xpath>
+                    <value>
+                        <modExtensions>
+                        <li Class="BetterArchitect.NestedCategoryExtension">
+                            <parentCategory>Ferny_Storage</parentCategory>
+                        </li>
+                        </modExtensions>
+                    </value>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
This adds compat folders for both mods following the same pattern as the Adaptive Storage Framework compat.

- `LWM_DS_Storage` → nested under Storage as "Deep Storage" (order 2)
- `SimpleStorage` → nested under Storage as "Simple Storage" (order 3)

Tested these patches on 1.6 against the current workshop build.